### PR TITLE
Modificaciones en solar7 de goes.py

### DIFF
--- a/stratopy/cloudsat.py
+++ b/stratopy/cloudsat.py
@@ -78,7 +78,7 @@ class CloudSatFrame:
     def __getattr__(self, a):
         return getattr(self._data, a)
 
-    def __repr__(self) -> (str):  # Es necesario el type hint?
+    def __repr__(self): 
         """repr(x) <=> x.__repr__()."""
         with pd.option_context("display.show_dimensions", False):
             df_body = repr(self._data).splitlines()
@@ -87,7 +87,7 @@ class CloudSatFrame:
         footer = f"\nCloudSatFrame - {sdf_dim}"
         return "\n".join(df_body + [footer])
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self):
         ad_id = id(self)
 
         with pd.option_context("display.show_dimensions", False):

--- a/stratopy/core.py
+++ b/stratopy/core.py
@@ -12,6 +12,7 @@ def geo2grid(lat, lon, nc):
     x, y = latlon2xy(lat, lon)
     col = (x - xoffset) / xscale
     lin = (y - yoffset) / yscale
+    
     return int(lin), int(col)
 
 

--- a/stratopy/core.py
+++ b/stratopy/core.py
@@ -12,7 +12,7 @@ def geo2grid(lat, lon, nc):
     x, y = latlon2xy(lat, lon)
     col = (x - xoffset) / xscale
     lin = (y - yoffset) / yscale
-    
+
     return int(lin), int(col)
 
 


### PR DESCRIPTION
Saqué solar7 de la clase Goes. Ahora es una función externa que se puede usar si uno va a procesar solo la banda 7