### PR TITLE
Goes.__repr__ , Goes._repr_html_ y test_read_nc_16 modificados

### DIFF
--- a/stratopy/goes.py
+++ b/stratopy/goes.py
@@ -91,7 +91,8 @@ def read_nc(file_path):
 class Goes:
 
     """Generates an object containing the Day Microphysics state
-    according to GOES-16 manual.
+    according to GOES-16 manual, along with all with all
+    netCDF.Dataset variables of original data.
 
     Parameters
     ----------
@@ -123,6 +124,11 @@ class Goes:
                 f"GOES Object -- {_img_date}, "
                 f"CH={bands[0]}, {bands[1]} and {bands[2]}"
             )
+        elif len(bands) == 16:
+            return (
+                f"GOES Object -- {_img_date}, "
+                f"CH={bands[0]} to CH={bands[-1]}"
+            )
         else:
             return ()
 
@@ -132,6 +138,11 @@ class Goes:
         footer = "<b>-- Goes Object</b>"
         if len(bands) == 1:
             return f"<div>{_img_date}, , CH={bands[0]} {footer}</div>"
+        elif len(bands) == 16:
+            return (
+                f"<div>{_img_date}, , "
+                f"CH={bands[0]} to CH={bands[-1]} {footer}</div>"
+            )
         else:
             return (
                 f"<div>{_img_date}, , "

--- a/stratopy/goes.py
+++ b/stratopy/goes.py
@@ -109,7 +109,6 @@ class Goes:
 
     _data = attr.ib(validator=attr.validators.instance_of(dict))
     coordinates = attr.ib(default=(-40.0, 10.0, -37.0, -80.0))
-
     _trim_coord = attr.ib(init=False)
     RGB = attr.ib(init=False)
     _img_date = attr.ib(init=False)


### PR DESCRIPTION
- Cambié Goes.__repr__ y Goes._repr_html_ para compatibilizar con archivos de 16 bandas.
- Agregué test_read_nc_16 a test_goes.py. Comprueba el funcionamiento de read_nc para archivos de 16 bandas:
    Como este tipo de archivos pesa alrededor de 400 MB, hice tuve que mockear netCDF.Dataset, 
    junto con algunos métodos de goes.Goes.